### PR TITLE
Improvement ::: Remove window click event listener on component unmount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-next-pickers",
-  "version": "0.0.8",
+  "version": "0.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,16 @@
   "name": "material-ui-next-pickers",
   "version": "0.0.12",
   "description": "Datepicker and timepicker for material-ui next",
-  "keywords": ["material-ui", "next", "date", "time", "datepicker", "timepicker", "calendar", "clock"],
+  "keywords": [
+    "material-ui",
+    "next",
+    "date",
+    "time",
+    "datepicker",
+    "timepicker",
+    "calendar",
+    "clock"
+  ],
   "repository": {
     "type": "github",
     "url": "https://github.com/chingyawhao/material-ui-next-pickers"

--- a/src/datepicker.tsx
+++ b/src/datepicker.tsx
@@ -56,14 +56,18 @@ class DateFormatInput extends React.Component<DateFormatInputProps, DateFormatIn
     }
   }
   componentDidMount() {
-    window.addEventListener('click', (event) => {
-      if([this.input, this.calendar].reduce((contain, next) => contain && (!next || next.compareDocumentPosition(event.target as Node) < 16), true)) {
-        this.closeCalendar()
-      }
-    })
+    window.addEventListener('click', this.handleWindowClick)
   }
   componentDidUpdate(prevProps, prevState) {
     if((prevProps.value && prevProps.value.getTime()) !== (this.props.value && this.props.value.getTime()) && prevState.calendarShow) {
+      this.closeCalendar()
+    }
+  }
+  componentWillUnmount() {
+    window.removeEventListener('click', this.handleWindowClick)
+  }
+  handleWindowClick = (event) => {
+    if([this.input, this.calendar].reduce((contain, next) => contain && (!next || next.compareDocumentPosition(event.target as Node) < 16), true)) {
       this.closeCalendar()
     }
   }


### PR DESCRIPTION
This PR will fix memory leak, when each Date Picker is adding an event handler to window, and don't remove it after unmounting.