### PR TITLE
Fix: Select ZERO in minutes

### DIFF
--- a/src/clock.tsx
+++ b/src/clock.tsx
@@ -180,14 +180,14 @@ class Clock extends React.Component<ClockProps, ClockState> {
     const {value, onChange, okToConfirm} = this.props
     const {selected} = this.state
     const date = new Date((okToConfirm? selected:value) || defaultTime)
-    if(selecting && label === 'hour') {
+    if(selecting >= 0 && label === 'hour') {
       date.setHours(selecting + ((value && value.getHours() >= 12)? 12:0))
-    } else if(selecting && label === 'minute') {
+    } else if(selecting >= 0 && label === 'minute') {
       date.setMinutes(selecting)
     }
-    if(selecting && okToConfirm) {
+    if(selecting >= 0 && okToConfirm) {
       this.setState({selecting:true, selected:date})
-    } else if(selecting) {
+    } else if(selecting >= 0) {
       this.setState({selecting:true}, () => onChange(date, event))
     }
   }


### PR DESCRIPTION
This fix logical problem in select minutes, when just check for **selecting** in IF will fall when minute is 0 (zero), so just change IF to:

`if (selecting >= 0)`