### PR TITLE
Add source maps inline

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "target": "es5",
     "lib": ["dom", "es2015", "es2016"],
-    "sourceMap": true,
+    "inlineSourceMap": true,
     "experimentalDecorators": true,
     "jsx": "react"
   },


### PR DESCRIPTION
Fixes the warnings detailed in:
https://github.com/chingyawhao/material-ui-next-pickers/issues/22
